### PR TITLE
Bug: Boot failure from permission error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -121,6 +121,7 @@ WorkingDirectory=$INSTALL_DIR
 Environment=PATH=$INSTALL_DIR/venv/bin:/usr/local/bin:/usr/bin:/bin
 Environment=DISPLAY=:0
 Environment=XAUTHORITY=/home/$USER/.Xauthority
+ExecStartPre=/bin/sleep 10
 ExecStart=$INSTALL_DIR/venv/bin/python main.py
 Restart=on-failure
 RestartSec=5

--- a/main.py
+++ b/main.py
@@ -6,13 +6,34 @@ from src.helpers import setup_logging, load_config
 # Set up logging and configuration  
 logger = setup_logging()
 IDLE_BRIGHTNESS, ACTIVE_BRIGHTNESS, DIM_DELAY_SECONDS, CHECK_INTERVAL = load_config()
-sc = ScreenControl()
+
+def initialize_screen_control():
+    """Attempts to initialize screen control with retries."""
+    max_init_retries = 30 # Try for up to 60 seconds (30 * 2s)
+    
+    for i in range(max_init_retries):
+        try:
+            return ScreenControl()
+        except Exception as e:
+            logger.warning("Failed to initialize screen control (attempt %d/%d): %s", 
+                         i+1, max_init_retries, e)
+            logger.info("Waiting for backlight permissions or device availability...")
+            time.sleep(2)
+    
+    raise RuntimeError("Could not initialize screen control after maximum retries")
 
 def main():
     logger.info("Starting Raspberry Pi Auto-Dimmer service")
     logger.info("Configuration: Idle brightness=%d%%, Active brightness=%d%%, Delay=%ds", 
                 IDLE_BRIGHTNESS, ACTIVE_BRIGHTNESS, DIM_DELAY_SECONDS)
     
+    # Initialize screen control safely
+    try:
+        sc = initialize_screen_control()
+    except RuntimeError as e:
+        logger.critical(str(e))
+        raise
+
     consecutive_errors = 0
     max_retries = 3
     


### PR DESCRIPTION
Occasionally, the Pi will not boot because the service attempts to access the backlight dimming properties before the backlight stuff is properly initialized.

This change implements a retry mechanism and a static delay to the service start to prevent these issues