### PR TITLE
Fix silent failure when backlight firmware isn't ready at boot

### DIFF
--- a/src/screen_control.py
+++ b/src/screen_control.py
@@ -1,22 +1,42 @@
 from rpi_backlight import Backlight
 from src.decorator import threaded
+from src.helpers import setup_logging
 import time
 
+
+log = setup_logging(__name__)
 
 
 class ScreenControl:
     def __init__(self):
         """Controls the screen backlight brightness and power state.
-        
+
         backlight: Instance of rpi_backlight.Backlight to manage the screen backlight.
         _changing_brightness: Flag indicating if a brightness change is in progress.
-        _brightness: Cached brightness level to track changes 
+        _brightness: Cached brightness level to track changes
             (because Backlight.brightness is sketch sometimes).
         """
         self.backlight = Backlight()
         self._changing_brightness = False
-        
-        self._brightness: int = -1  
+
+        self._brightness: int = -1
+
+        # Probe the backlight to confirm the firmware is ready to accept
+        # brightness writes. On cold boot the Pi firmware can reject mailbox
+        # requests (kernel reports "Failed to write system 'brightness'
+        # attribute: Invalid argument"). Constructing Backlight() does not
+        # exercise a write, so without this probe the service would appear
+        # healthy while every subsequent write silently failed on the
+        # threaded fade worker. Raising here lets the caller's
+        # @retry_on_exception back off and try again.
+        self._probe_writable()
+
+    def _probe_writable(self) -> None:
+        """Write the current brightness back to itself to confirm the
+        backlight sysfs attribute accepts writes. Raises OSError if the
+        firmware is not ready yet."""
+        current = self.backlight.brightness
+        self.backlight.brightness = current
 
     @property
     def brightness(self) -> int:
@@ -54,12 +74,27 @@ class ScreenControl:
         try:
             if target_brightness > current_brightness:
                 for b in range(current_brightness, target_brightness + 1, step):
-                    self.backlight.brightness = b
+                    self._write_brightness(b)
                     time.sleep(delay)
             else:
                 for b in range(current_brightness, target_brightness - 1, -step):
-                    self.backlight.brightness = b
+                    self._write_brightness(b)
                     time.sleep(delay)
+            self._write_brightness(target_brightness)
+        except OSError as e:
+            # Writes to the sysfs brightness attribute can fail with EINVAL
+            # when the Pi firmware is momentarily unavailable. Because this
+            # runs on a daemon thread, an unhandled exception would be
+            # swallowed silently and the service would appear healthy while
+            # doing nothing. Log it, invalidate the cached brightness so the
+            # next set_brightness call re-reads reality, and let the main
+            # loop try again.
+            log.warning("Failed to write backlight brightness: %s", e)
+            self._brightness = -1
         finally:
-            self.backlight.brightness = target_brightness
             self._changing_brightness = False
+
+    def _write_brightness(self, value: int) -> None:
+        """Single brightness write, isolated so callers can reason about
+        where OSErrors originate."""
+        self.backlight.brightness = value

--- a/src/screen_control.py
+++ b/src/screen_control.py
@@ -1,7 +1,8 @@
+import time
+
 from rpi_backlight import Backlight
 from src.decorator import threaded
 from src.helpers import setup_logging
-import time
 
 
 log = setup_logging(__name__)
@@ -36,7 +37,7 @@ class ScreenControl:
         backlight sysfs attribute accepts writes. Raises OSError if the
         firmware is not ready yet."""
         current = self.backlight.brightness
-        self.backlight.brightness = current
+        self._write_brightness(current)
 
     @property
     def brightness(self) -> int:
@@ -89,7 +90,7 @@ class ScreenControl:
             # doing nothing. Log it, invalidate the cached brightness so the
             # next set_brightness call re-reads reality, and let the main
             # loop try again.
-            log.warning("Failed to write backlight brightness: %s", e)
+            log.warning("Failed to write backlight brightness (target=%d)", target_brightness, exc_info=True)
             self._brightness = -1
         finally:
             self._changing_brightness = False

--- a/src/screen_control.py
+++ b/src/screen_control.py
@@ -10,34 +10,15 @@ log = setup_logging(__name__)
 
 class ScreenControl:
     def __init__(self):
-        """Controls the screen backlight brightness and power state.
-
-        backlight: Instance of rpi_backlight.Backlight to manage the screen backlight.
-        _changing_brightness: Flag indicating if a brightness change is in progress.
-        _brightness: Cached brightness level to track changes
-            (because Backlight.brightness is sketch sometimes).
-        """
         self.backlight = Backlight()
         self._changing_brightness = False
-
         self._brightness: int = -1
-
-        # Probe the backlight to confirm the firmware is ready to accept
-        # brightness writes. On cold boot the Pi firmware can reject mailbox
-        # requests (kernel reports "Failed to write system 'brightness'
-        # attribute: Invalid argument"). Constructing Backlight() does not
-        # exercise a write, so without this probe the service would appear
-        # healthy while every subsequent write silently failed on the
-        # threaded fade worker. Raising here lets the caller's
-        # @retry_on_exception back off and try again.
+        # Raises OSError if firmware isn't ready; lets @retry_on_exception handle boot delays.
         self._probe_writable()
 
     def _probe_writable(self) -> None:
-        """Write the current brightness back to itself to confirm the
-        backlight sysfs attribute accepts writes. Raises OSError if the
-        firmware is not ready yet."""
-        current = self.backlight.brightness
-        self._write_brightness(current)
+        """Raises OSError if the sysfs brightness attribute isn't writable yet."""
+        self._write_brightness(self.backlight.brightness)
 
     @property
     def brightness(self) -> int:
@@ -82,20 +63,11 @@ class ScreenControl:
                     self._write_brightness(b)
                     time.sleep(delay)
             self._write_brightness(target_brightness)
-        except OSError as e:
-            # Writes to the sysfs brightness attribute can fail with EINVAL
-            # when the Pi firmware is momentarily unavailable. Because this
-            # runs on a daemon thread, an unhandled exception would be
-            # swallowed silently and the service would appear healthy while
-            # doing nothing. Log it, invalidate the cached brightness so the
-            # next set_brightness call re-reads reality, and let the main
-            # loop try again.
+        except OSError:
             log.warning("Failed to write backlight brightness (target=%d)", target_brightness, exc_info=True)
             self._brightness = -1
         finally:
             self._changing_brightness = False
 
     def _write_brightness(self, value: int) -> None:
-        """Single brightness write, isolated so callers can reason about
-        where OSErrors originate."""
         self.backlight.brightness = value


### PR DESCRIPTION
## Summary
- Probe the backlight sysfs attribute in `ScreenControl.__init__` with a write-current-back-to-itself call, so firmware-not-ready conditions raise during init and the existing `@retry_on_exception(max_retries=5, delay=5)` on `initialize_screen_control` actually does its job.
- Catch `OSError` inside `_fade_backlight` so transient firmware errors on the daemon worker thread get logged and invalidate the cached brightness, instead of being swallowed silently.

## Why
Observed on a Pi 5 kiosk: after a cold boot the firmware sometimes rejects brightness writes (`raspberrypi-firmware ... status 0x80000001`, sysfs write returns `EINVAL`). `Backlight()` construction does not touch the sysfs attribute, so `ScreenControl()` succeeded and every subsequent write died on the fade thread with no log and no retry. Service reported active, screen never dimmed.

## Test plan
- [x] On a Pi that normally boots fine, confirm the service still starts and dims as before.
- [x] Simulate firmware-not-ready by chmod'ing `/sys/class/backlight/rpi_backlight/brightness` unwritable briefly at boot; confirm the init probe raises, `initialize_screen_control` retries, and the service recovers once writes succeed.
- [x] During normal operation, force an `OSError` on a single write and confirm the warning is logged instead of the thread dying silently.

Closes #6